### PR TITLE
Introduce ability to stop nodes

### DIFF
--- a/chaoskube/action.go
+++ b/chaoskube/action.go
@@ -10,15 +10,35 @@ import (
 	"os"
 )
 
-type PodAction interface {
+type NodeAction interface {
 	// Imbue chaos in the given victim
-	ApplyChaos(victim v1.Pod) error
+	ApplyToNode(client kubernetes.Interface, victim *v1.Node) error
 	// Name of this action, ideally a verb - like "terminate pod"
 	Name() string
 }
 
-func NewDryRunAction() PodAction {
-	return &dryRun{}
+func NewDeleteNodeAction() NodeAction {
+	return &deleteNode{}
+}
+
+type deleteNode struct{}
+
+func (a *deleteNode) ApplyToNode(client kubernetes.Interface, victim *v1.Node) error {
+	return client.CoreV1().Nodes().Delete(victim.Name, nil)
+}
+func (a *deleteNode) Name() string {
+	return "delete node"
+}
+
+type PodAction interface {
+	// Imbue chaos in the given victim
+	ApplyToPod(victim v1.Pod) error
+	// Name of this action, ideally a verb - like "terminate pod"
+	Name() string
+}
+
+func NewDryRunPodAction() PodAction {
+	return &podDryRun{}
 }
 
 func NewDeletePodAction(client kubernetes.Interface) PodAction {
@@ -30,25 +50,25 @@ func NewExecAction(client restclient.Interface, config *restclient.Config, conta
 }
 
 // no-op
-type dryRun struct {
+type podDryRun struct {
 }
 
-func (s *dryRun) ApplyChaos(victim v1.Pod) error {
+func (s *podDryRun) ApplyToPod(victim v1.Pod) error {
 	return nil
 }
-func (s *dryRun) Name() string { return "dry run" }
+func (s *podDryRun) Name() string { return "dry run" }
 
-var _ PodAction = &dryRun{}
+var _ PodAction = &podDryRun{}
 
 // Simply ask k8s to delete the victim pod
 type deletePod struct {
 	client kubernetes.Interface
 }
 
-func (s *deletePod) ApplyChaos(victim v1.Pod) error {
+func (s *deletePod) ApplyToPod(victim v1.Pod) error {
 	return s.client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
 }
-func (s *deletePod) Name() string { return "terminating pod" }
+func (s *deletePod) Name() string { return "delete pod" }
 
 var _ PodAction = &deletePod{}
 
@@ -62,7 +82,7 @@ type execOnPod struct {
 }
 
 // Based on https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/exec.go
-func (s *execOnPod) ApplyChaos(pod v1.Pod) error {
+func (s *execOnPod) ApplyToPod(pod v1.Pod) error {
 	var container string
 	if s.containerName == "" {
 		for _, c := range pod.Spec.Containers {

--- a/chaoskube/action.go
+++ b/chaoskube/action.go
@@ -1,55 +1,56 @@
 package chaoskube
 
 import (
+	"fmt"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"os"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/kubernetes/scheme"
-	"fmt"
 )
 
-type ChaosAction interface {
+type PodAction interface {
 	// Imbue chaos in the given victim
 	ApplyChaos(victim v1.Pod) error
 	// Name of this action, ideally a verb - like "terminate pod"
 	Name() string
 }
 
-func NewDryRunAction() ChaosAction {
+func NewDryRunAction() PodAction {
 	return &dryRun{}
 }
 
-func NewDeletePodAction(client kubernetes.Interface) ChaosAction {
+func NewDeletePodAction(client kubernetes.Interface) PodAction {
 	return &deletePod{client}
 }
 
-func NewExecAction(client restclient.Interface, config *restclient.Config, containerName string, command []string) ChaosAction {
+func NewExecAction(client restclient.Interface, config *restclient.Config, containerName string, command []string) PodAction {
 	return &execOnPod{client, config, containerName, command}
 }
 
 // no-op
 type dryRun struct {
-
 }
+
 func (s *dryRun) ApplyChaos(victim v1.Pod) error {
 	return nil
 }
 func (s *dryRun) Name() string { return "dry run" }
 
-var _ ChaosAction = &dryRun{}
+var _ PodAction = &dryRun{}
 
 // Simply ask k8s to delete the victim pod
 type deletePod struct {
 	client kubernetes.Interface
 }
+
 func (s *deletePod) ApplyChaos(victim v1.Pod) error {
 	return s.client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
 }
 func (s *deletePod) Name() string { return "terminating pod" }
 
-var _ ChaosAction = &deletePod{}
+var _ PodAction = &deletePod{}
 
 // Execute the given command on victim pods
 type execOnPod struct {
@@ -57,7 +58,7 @@ type execOnPod struct {
 	config *restclient.Config
 
 	containerName string
-	command []string
+	command       []string
 }
 
 // Based on https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/exec.go
@@ -92,7 +93,7 @@ func (s *execOnPod) ApplyChaos(pod v1.Pod) error {
 		return err
 	}
 	// TODO: Collect stderr/stdout in RAM and log
-	err =  exec.Stream(remotecommand.StreamOptions{
+	err = exec.Stream(remotecommand.StreamOptions{
 		Stdin:             nil,
 		Stdout:            os.Stdout,
 		Stderr:            os.Stderr,
@@ -103,4 +104,5 @@ func (s *execOnPod) ApplyChaos(pod v1.Pod) error {
 	return err
 }
 func (s *execOnPod) Name() string { return fmt.Sprintf("exec '%v'", s.command) }
-var _ ChaosAction = &execOnPod{}
+
+var _ PodAction = &execOnPod{}

--- a/chaoskube/action_test.go
+++ b/chaoskube/action_test.go
@@ -1,0 +1,41 @@
+package chaoskube_test
+
+import (
+	"github.com/neo-technology/marmoset/chaoskube"
+	"k8s.io/api/core/v1"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+func TestDeleteNodeAction(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	noTouching := &v1.Node{
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name: "shouldnt-be-touched-node",
+		},
+	}
+	client := fake.NewSimpleClientset(node, noTouching)
+	action := chaoskube.NewDeleteNodeAction()
+
+	err := action.ApplyToNode(client, node)
+
+	if err != nil {
+		t.Fatalf("Expected smooth sailing, got: %s", err)
+	}
+
+	nodes, _ := client.CoreV1().Nodes().List(k8smeta.ListOptions{})
+	if len(nodes.Items) > 1 {
+		t.Fatalf("Expected the node to have been deleted, found: %v", nodes.Items)
+	}
+	if len(nodes.Items) < 1 {
+		t.Fatalf("Expected the extra node to be left alone, but found no nodes")
+	}
+	if nodes.Items[0].Name != noTouching.Name {
+		t.Fatalf("Expected the extra node to not have been touched, but the surviving node is: %v", nodes.Items[0])
+	}
+}

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -405,7 +405,7 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 	client := fake.NewSimpleClientset()
 	action := NewDeletePodAction(client)
 	if dryRun {
-		action = NewDryRunAction()
+		action = NewDryRunPodAction()
 	}
 
 	chaosSpec := &PodChaosSpec{

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -3,7 +3,6 @@ package chaoskube
 import (
 	"context"
 	"github.com/neo-technology/marmoset/util"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -11,8 +10,8 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/stretchr/testify/suite"
@@ -35,42 +34,30 @@ func (suite *Suite) SetupTest() {
 func (suite *Suite) TestNew() {
 	var (
 		client             = fake.NewSimpleClientset()
-		labelSelector, _   = labels.Parse("foo=bar")
-		annotations, _     = labels.Parse("baz=waldo")
-		namespaces, _      = labels.Parse("qux")
 		excludedWeekdays   = []time.Weekday{time.Friday}
-		excludedTimesOfDay = []util.TimePeriod{util.TimePeriod{}}
+		excludedTimesOfDay = []util.TimePeriod{{}}
 		excludedDaysOfYear = []time.Time{time.Now()}
-		minimumAge         = time.Duration(42)
 	)
 
-	action := NewDeletePodAction(client)
+	chaosSpec := &PodChaosSpec{}
 	chaoskube := New(
 		client,
-		labelSelector,
-		annotations,
-		namespaces,
+		chaosSpec,
 		excludedWeekdays,
 		excludedTimesOfDay,
 		excludedDaysOfYear,
 		time.UTC,
-		minimumAge,
 		logger,
-		action,
 	)
 	suite.Require().NotNil(chaoskube)
 
 	suite.Equal(client, chaoskube.Client)
-	suite.Equal("foo=bar", chaoskube.Labels.String())
-	suite.Equal("baz=waldo", chaoskube.Annotations.String())
-	suite.Equal("qux", chaoskube.Namespaces.String())
+	suite.Equal(chaosSpec, chaoskube.Spec)
 	suite.Equal(excludedWeekdays, chaoskube.ExcludedWeekdays)
 	suite.Equal(excludedTimesOfDay, chaoskube.ExcludedTimesOfDay)
 	suite.Equal(excludedDaysOfYear, chaoskube.ExcludedDaysOfYear)
 	suite.Equal(time.UTC, chaoskube.Timezone)
-	suite.Equal(minimumAge, chaoskube.MinimumAge)
 	suite.Equal(logger, chaoskube.Logger)
-	suite.Equal(action, chaoskube.Action)
 }
 
 // TestRunContextCanceled tests that a canceled context will exit the Run function.
@@ -93,143 +80,6 @@ func (suite *Suite) TestRunContextCanceled() {
 	chaoskube.Run(ctx, nil)
 }
 
-func (suite *Suite) TestCandidates() {
-	foo := map[string]string{"namespace": "default", "name": "foo"}
-	bar := map[string]string{"namespace": "testing", "name": "bar"}
-
-	for _, tt := range []struct {
-		labelSelector      string
-		annotationSelector string
-		namespaceSelector  string
-		pods               []map[string]string
-	}{
-		{"", "", "", []map[string]string{foo, bar}},
-		{"app=foo", "", "", []map[string]string{foo}},
-		{"app!=foo", "", "", []map[string]string{bar}},
-		{"", "chaos=foo", "", []map[string]string{foo}},
-		{"", "chaos!=foo", "", []map[string]string{bar}},
-		{"", "", "default", []map[string]string{foo}},
-		{"", "", "default,testing", []map[string]string{foo, bar}},
-		{"", "", "!testing", []map[string]string{foo}},
-		{"", "", "!default,!testing", []map[string]string{}},
-		{"", "", "default,!testing", []map[string]string{foo}},
-		{"", "", "default,!default", []map[string]string{}},
-	} {
-		labelSelector, err := labels.Parse(tt.labelSelector)
-		suite.Require().NoError(err)
-
-		annotationSelector, err := labels.Parse(tt.annotationSelector)
-		suite.Require().NoError(err)
-
-		namespaceSelector, err := labels.Parse(tt.namespaceSelector)
-		suite.Require().NoError(err)
-
-		chaoskube := suite.setupWithPods(
-			labelSelector,
-			annotationSelector,
-			namespaceSelector,
-			[]time.Weekday{},
-			[]util.TimePeriod{},
-			[]time.Time{},
-			time.UTC,
-			time.Duration(0),
-			false,
-		)
-
-		suite.assertCandidates(chaoskube, tt.pods)
-	}
-}
-
-func (suite *Suite) TestVictim() {
-	foo := map[string]string{"namespace": "default", "name": "foo"}
-	bar := map[string]string{"namespace": "testing", "name": "bar"}
-
-	for _, tt := range []struct {
-		seed          int64
-		labelSelector string
-		victim        map[string]string
-	}{
-		{2000, "", foo},
-		{4000, "", bar},
-		{4000, "app=foo", foo},
-	} {
-		rand.Seed(tt.seed)
-
-		labelSelector, err := labels.Parse(tt.labelSelector)
-		suite.Require().NoError(err)
-
-		chaoskube := suite.setupWithPods(
-			labelSelector,
-			labels.Everything(),
-			labels.Everything(),
-			[]time.Weekday{},
-			[]util.TimePeriod{},
-			[]time.Time{},
-			time.UTC,
-			time.Duration(0),
-			false,
-		)
-
-		suite.assertVictim(chaoskube, tt.victim)
-	}
-}
-
-// TestNoVictimReturnsError tests that on missing victim it returns a known error
-func (suite *Suite) TestNoVictimReturnsError() {
-	chaoskube := suite.setup(
-		labels.Everything(),
-		labels.Everything(),
-		labels.Everything(),
-		[]time.Weekday{},
-		[]util.TimePeriod{},
-		[]time.Time{},
-		time.UTC,
-		time.Duration(0),
-		false,
-	)
-
-	_, err := chaoskube.Victim()
-	suite.Equal(err, errPodNotFound)
-	suite.EqualError(err, "pod not found")
-}
-
-func (suite *Suite) TestDeletePod() {
-	foo := map[string]string{"namespace": "default", "name": "foo"}
-	bar := map[string]string{"namespace": "testing", "name": "bar"}
-
-	for _, tt := range []struct {
-		dryRun        bool
-		remainingPods []map[string]string
-	}{
-		{false, []map[string]string{bar}},
-		{true, []map[string]string{foo, bar}},
-	} {
-		chaoskube := suite.setupWithPods(
-			labels.Everything(),
-			labels.Everything(),
-			labels.Everything(),
-			[]time.Weekday{},
-			[]util.TimePeriod{},
-			[]time.Time{},
-			time.UTC,
-			time.Duration(0),
-			tt.dryRun,
-		)
-
-		victim := util.NewPod("default", "foo", v1.PodRunning)
-
-		err := chaoskube.ApplyChaos(victim)
-		suite.Require().NoError(err)
-
-		if tt.dryRun {
-			suite.assertLog(log.InfoLevel, "dry run", log.Fields{"namespace": "default", "name": "foo"})
-		} else {
-			suite.assertLog(log.InfoLevel, "terminating pod", log.Fields{"namespace": "default", "name": "foo"})
-		}
-		suite.assertCandidates(chaoskube, tt.remainingPods)
-	}
-}
-
 func (suite *Suite) TestTerminateVictim() {
 	midnight := util.NewTimePeriod(
 		ThankGodItsFriday{}.Now().Add(-16*time.Hour),
@@ -246,6 +96,8 @@ func (suite *Suite) TestTerminateVictim() {
 
 	australia, err := time.LoadLocation("Australia/Brisbane")
 	suite.Require().NoError(err)
+	expectSpecInvoked := true
+	expectSpecNotInvoked := false
 
 	for _, tt := range []struct {
 		excludedWeekdays   []time.Weekday
@@ -253,7 +105,7 @@ func (suite *Suite) TestTerminateVictim() {
 		excludedDaysOfYear []time.Time
 		now                func() time.Time
 		timezone           *time.Location
-		remainingPodCount  int
+		expectSpecInvoked  bool
 	}{
 		// no time is excluded, one pod should be killed
 		{
@@ -262,7 +114,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 		// current weekday is excluded, no pod should be killed
 		{
@@ -271,7 +123,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// current time of day is excluded, no pod should be killed
 		{
@@ -280,7 +132,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// one day after an excluded weekday, one pod should be killed
 		{
@@ -289,7 +141,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(24 * time.Hour) },
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 		// seven days after an excluded weekday, no pod should be killed
 		{
@@ -298,7 +150,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(7 * 24 * time.Hour) },
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// one hour after an excluded time period, one pod should be killed
 		{
@@ -307,7 +159,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(+2 * time.Hour) },
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 		// twenty four hours after an excluded time period, no pod should be killed
 		{
@@ -316,7 +168,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(+24 * time.Hour) },
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// current weekday is excluded but we are in another time zone, one pod should be killed
 		{
@@ -325,7 +177,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			australia,
-			1,
+			expectSpecInvoked,
 		},
 		// current time period is excluded but we are in another time zone, one pod should be killed
 		{
@@ -334,7 +186,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			australia,
-			1,
+			expectSpecInvoked,
 		},
 		// one out of two excluded weeksdays match, no pod should be killed
 		{
@@ -343,7 +195,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// one out of two excluded time periods match, no pod should be killed
 		{
@@ -352,7 +204,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			ThankGodItsFriday{}.Now,
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// we're inside an excluded time period across days, no pod should be killed
 		{
@@ -361,7 +213,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(-15 * time.Hour) },
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// we're before an excluded time period across days, one pod should be killed
 		{
@@ -370,7 +222,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(-17 * time.Hour) },
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 		// we're after an excluded time period across days, one pod should be killed
 		{
@@ -379,7 +231,7 @@ func (suite *Suite) TestTerminateVictim() {
 			[]time.Time{},
 			func() time.Time { return ThankGodItsFriday{}.Now().Add(-13 * time.Hour) },
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 		// this day of year is excluded, no pod should be killed
 		{
@@ -390,7 +242,7 @@ func (suite *Suite) TestTerminateVictim() {
 			},
 			func() time.Time { return ThankGodItsFriday{}.Now() },
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// this day of year in year 0 is excluded, no pod should be killed
 		{
@@ -401,7 +253,7 @@ func (suite *Suite) TestTerminateVictim() {
 			},
 			func() time.Time { return ThankGodItsFriday{}.Now() },
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// matching works fine even when multiple days-of-year are provided, no pod should be killed
 		{
@@ -413,7 +265,7 @@ func (suite *Suite) TestTerminateVictim() {
 			},
 			func() time.Time { return ThankGodItsFriday{}.Now() },
 			time.UTC,
-			2,
+			expectSpecNotInvoked,
 		},
 		// there is an excluded day of year but it's not today, one pod should be killed
 		{
@@ -424,7 +276,7 @@ func (suite *Suite) TestTerminateVictim() {
 			},
 			func() time.Time { return ThankGodItsFriday{}.Now() },
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 		// there is an excluded day of year but the month is different, one pod should be killed
 		{
@@ -435,7 +287,7 @@ func (suite *Suite) TestTerminateVictim() {
 			},
 			func() time.Time { return ThankGodItsFriday{}.Now() },
 			time.UTC,
-			1,
+			expectSpecInvoked,
 		},
 	} {
 		chaoskube := suite.setupWithPods(
@@ -449,15 +301,17 @@ func (suite *Suite) TestTerminateVictim() {
 			time.Duration(0),
 			false,
 		)
+		recorder := &chaosRecorder{}
+		chaoskube.Spec = recorder
 		chaoskube.Now = tt.now
 
 		err := chaoskube.TerminateVictim()
 		suite.Require().NoError(err)
 
-		pods, err := chaoskube.Candidates()
+		err = chaoskube.TerminateVictim()
 		suite.Require().NoError(err)
 
-		suite.Len(pods, tt.remainingPodCount)
+		suite.Require().Equal(tt.expectSpecInvoked, recorder.invoked)
 	}
 }
 
@@ -483,19 +337,16 @@ func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 
 // helper functions
 
-func (suite *Suite) assertCandidates(chaoskube *Chaoskube, expected []map[string]string) {
-	pods, err := chaoskube.Candidates()
-	suite.Require().NoError(err)
-
-	suite.assertPods(pods, expected)
+type chaosRecorder struct {
+	invoked bool
 }
 
-func (suite *Suite) assertVictim(chaoskube *Chaoskube, expected map[string]string) {
-	victim, err := chaoskube.Victim()
-	suite.Require().NoError(err)
-
-	suite.assertPod(victim, expected)
+func (r *chaosRecorder) Apply(k8sclient clientset.Interface, now time.Time) error {
+	r.invoked = true
+	return nil
 }
+
+var _ ChaosSpec = &chaosRecorder{}
 
 func (suite *Suite) assertPods(pods []v1.Pod, expected []map[string]string) {
 	suite.Require().Len(pods, len(expected))
@@ -557,18 +408,22 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		action = NewDryRunAction()
 	}
 
+	chaosSpec := &PodChaosSpec{
+		Action:      action,
+		Labels:      labelSelector,
+		Annotations: annotations,
+		Namespaces:  namespaces,
+		MinimumAge:  minimumAge,
+		Logger:      logger,
+	}
 	return New(
 		client,
-		labelSelector,
-		annotations,
-		namespaces,
+		chaosSpec,
 		excludedWeekdays,
 		excludedTimesOfDay,
 		excludedDaysOfYear,
 		timezone,
-		minimumAge,
 		logger,
-		action,
 	)
 }
 
@@ -583,104 +438,4 @@ type ThankGodItsFriday struct{}
 func (t ThankGodItsFriday) Now() time.Time {
 	blackFriday, _ := time.Parse(time.RFC1123, "Fri, 24 Sep 1869 15:04:05 UTC")
 	return blackFriday
-}
-
-func (suite *Suite) TestMinimumAge() {
-	type pod struct {
-		name         string
-		namespace    string
-		creationTime time.Time
-	}
-
-	for _, tt := range []struct {
-		minimumAge time.Duration
-		now        func() time.Time
-		pods       []pod
-		candidates int
-	}{
-		// no minimum age set
-		{
-			time.Duration(0),
-			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
-			[]pod{
-				{
-					name:         "test1",
-					namespace:    "test",
-					creationTime: time.Date(0, 10, 24, 9, 00, 00, 00, time.UTC),
-				},
-			},
-			1,
-		},
-		// minimum age set, but pod is too young
-		{
-			time.Hour * 1,
-			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
-			[]pod{
-				{
-					name:         "test1",
-					namespace:    "test",
-					creationTime: time.Date(0, 10, 24, 9, 30, 00, 00, time.UTC),
-				},
-			},
-			0,
-		},
-		// one pod is too young, one matches
-		{
-			time.Hour * 1,
-			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
-			[]pod{
-				// too young
-				{
-					name:         "test1",
-					namespace:    "test",
-					creationTime: time.Date(0, 10, 24, 9, 30, 00, 00, time.UTC),
-				},
-				// matches
-				{
-					name:         "test2",
-					namespace:    "test",
-					creationTime: time.Date(0, 10, 23, 8, 00, 00, 00, time.UTC),
-				},
-			},
-			1,
-		},
-		// exact time - should not match
-		{
-			time.Hour * 1,
-			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
-			[]pod{
-				{
-					name:         "test1",
-					namespace:    "test",
-					creationTime: time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC),
-				},
-			},
-			0,
-		},
-	} {
-		chaoskube := suite.setup(
-			labels.Everything(),
-			labels.Everything(),
-			labels.Everything(),
-			[]time.Weekday{},
-			[]util.TimePeriod{},
-			[]time.Time{},
-			time.UTC,
-			tt.minimumAge,
-			false,
-		)
-		chaoskube.Now = tt.now
-
-		for _, p := range tt.pods {
-			pod := util.NewPod(p.namespace, p.name, v1.PodRunning)
-			pod.ObjectMeta.CreationTimestamp = metav1.Time{Time: p.creationTime}
-			_, err := chaoskube.Client.Core().Pods(pod.Namespace).Create(&pod)
-			suite.Require().NoError(err)
-		}
-
-		pods, err := chaoskube.Candidates()
-		suite.Require().NoError(err)
-
-		suite.Len(pods, tt.candidates)
-	}
 }

--- a/chaoskube/logging.go
+++ b/chaoskube/logging.go
@@ -18,7 +18,7 @@ func SetupLogging(debug bool, logFormat string, logFields string) log.FieldLogge
 	if logFormat == "json" {
 		logger.Formatter = &log.JSONFormatter{
 			FieldMap: log.FieldMap{
-				log.FieldKeyMsg: "message",
+				log.FieldKeyMsg:   "message",
 				log.FieldKeyLevel: "severity",
 			},
 		}

--- a/chaoskube/logging.go
+++ b/chaoskube/logging.go
@@ -25,15 +25,17 @@ func SetupLogging(debug bool, logFormat string, logFields string) log.FieldLogge
 	}
 
 	fields := log.Fields{}
-	fieldPairs := strings.Split(logFields, ",")
-	for _, pair := range fieldPairs {
-		parts := strings.Split(pair, "=")
-		if len(parts) != 2 {
-			log.WithFields(log.Fields{
-				"logFields": logFields,
-			}).Fatal("failed to parse default log field argument")
+	if strings.TrimSpace(logFields) != "" {
+		fieldPairs := strings.Split(logFields, ",")
+		for _, pair := range fieldPairs {
+			parts := strings.Split(pair, "=")
+			if len(parts) != 2 {
+				log.WithFields(log.Fields{
+					"logFields": logFields,
+				}).Fatal("failed to parse default log field argument")
+			}
+			fields[parts[0]] = parts[1]
 		}
-		fields[parts[0]] = parts[1]
 	}
 
 	return logger.WithFields(fields)

--- a/chaoskube/logging_test.go
+++ b/chaoskube/logging_test.go
@@ -27,7 +27,7 @@ func (suite *Suite) TestSetsDefaultFields() {
 	suite.Equal(os.Stdout, entry.Logger.Out)
 	suite.Equal(&log.JSONFormatter{
 		FieldMap: log.FieldMap{
-			log.FieldKeyMsg: "message",
+			log.FieldKeyMsg:   "message",
 			log.FieldKeyLevel: "severity",
 		},
 	}, entry.Logger.Formatter)

--- a/chaoskube/spec.go
+++ b/chaoskube/spec.go
@@ -1,0 +1,196 @@
+package chaoskube
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	clientset "k8s.io/client-go/kubernetes"
+	"math/rand"
+	"time"
+)
+
+type ChaosSpec interface {
+	Apply(k8sclient clientset.Interface, now time.Time) error
+}
+
+type PodChaosSpec struct {
+	Action PodAction
+	// a label selector which restricts the pods to choose from
+	Labels labels.Selector
+	// an annotation selector which restricts the pods to choose from
+	Annotations labels.Selector
+	// a namespace selector which restricts the pods to choose from
+	Namespaces labels.Selector
+	// minimum age of pods to consider
+	MinimumAge time.Duration
+	// an instance of logrus.StdLogger to write log messages to
+	Logger log.FieldLogger
+}
+
+func (s *PodChaosSpec) Apply(client clientset.Interface, now time.Time) error {
+	candidates, err := s.candidates(client, now)
+	if err != nil {
+		return err
+	}
+
+	if len(candidates) == 0 {
+		s.Logger.Debugf(msgVictimNotFound)
+		return nil
+	}
+
+	index := rand.Intn(len(candidates))
+	victim := candidates[index]
+
+	s.Logger.WithFields(log.Fields{
+		"namespace": victim.Namespace,
+		"name":      victim.Name,
+	}).Info(s.Action.Name())
+
+	return s.Action.ApplyChaos(victim)
+}
+
+func (s *PodChaosSpec) candidates(client clientset.Interface, now time.Time) ([]v1.Pod, error) {
+	listOptions := metav1.ListOptions{LabelSelector: s.Labels.String()}
+
+	podList, err := client.CoreV1().Pods(v1.NamespaceAll).List(listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := filterByNamespaces(podList.Items, s.Namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	pods = filterByAnnotations(pods, s.Annotations)
+	pods = filterByPhase(pods, v1.PodRunning)
+	pods = filterByMinimumAge(pods, s.MinimumAge, now)
+
+	return pods, nil
+}
+
+func NewPodChaosSpec(action PodAction, labels, annotations, namespaces labels.Selector, minimumAge time.Duration,
+	logger log.FieldLogger) ChaosSpec {
+	return &PodChaosSpec{
+		Action:      action,
+		Labels:      labels,
+		Annotations: annotations,
+		Namespaces:  namespaces,
+		MinimumAge:  minimumAge,
+		Logger:      logger,
+	}
+}
+
+// filterByNamespaces filters a list of pods by a given namespace selector.
+func filterByNamespaces(pods []v1.Pod, namespaces labels.Selector) ([]v1.Pod, error) {
+	// empty filter returns original list
+	if namespaces.Empty() {
+		return pods, nil
+	}
+
+	// split requirements into including and excluding groups
+	reqs, _ := namespaces.Requirements()
+	reqIncl := []labels.Requirement{}
+	reqExcl := []labels.Requirement{}
+
+	for _, req := range reqs {
+		switch req.Operator() {
+		case selection.Exists:
+			reqIncl = append(reqIncl, req)
+		case selection.DoesNotExist:
+			reqExcl = append(reqExcl, req)
+		default:
+			return nil, fmt.Errorf("unsupported operator: %s", req.Operator())
+		}
+	}
+
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		// if there aren't any including requirements, we're in by default
+		included := len(reqIncl) == 0
+
+		// convert the pod's namespace to an equivalent label selector
+		selector := labels.Set{pod.Namespace: ""}
+
+		// include pod if one including requirement matches
+		for _, req := range reqIncl {
+			if req.Matches(selector) {
+				included = true
+				break
+			}
+		}
+
+		// exclude pod if it is filtered out by at least one excluding requirement
+		for _, req := range reqExcl {
+			if !req.Matches(selector) {
+				included = false
+				break
+			}
+		}
+
+		if included {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList, nil
+}
+
+// filterByAnnotations filters a list of pods by a given annotation selector.
+func filterByAnnotations(pods []v1.Pod, annotations labels.Selector) []v1.Pod {
+	// empty filter returns original list
+	if annotations.Empty() {
+		return pods
+	}
+
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		// convert the pod's annotations to an equivalent label selector
+		selector := labels.Set(pod.Annotations)
+
+		// include pod if its annotations match the selector
+		if annotations.Matches(selector) {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList
+}
+
+// filterByPhase filters a list of pods by a given PodPhase, e.g. Running.
+func filterByPhase(pods []v1.Pod, phase v1.PodPhase) []v1.Pod {
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		if pod.Status.Phase == phase {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList
+}
+
+// filterByMinimumAge filters pods by creation time. Only pods
+// older than minimumAge are returned
+func filterByMinimumAge(pods []v1.Pod, minimumAge time.Duration, now time.Time) []v1.Pod {
+	if minimumAge <= time.Duration(0) {
+		return pods
+	}
+
+	creationTime := now.Add(-minimumAge)
+
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		if pod.ObjectMeta.CreationTimestamp.Time.Before(creationTime) {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList
+}

--- a/chaoskube/spec_test.go
+++ b/chaoskube/spec_test.go
@@ -1,0 +1,193 @@
+package chaoskube_test
+
+import (
+	"fmt"
+	"github.com/neo-technology/marmoset/chaoskube"
+	"github.com/neo-technology/marmoset/util"
+	"github.com/sirupsen/logrus/hooks/test"
+	"k8s.io/api/core/v1"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+	"time"
+)
+
+var (
+	logger, logOutput = test.NewNullLogger()
+)
+
+var now = time.Date(1773, 12, 16, 18, 10, 23, 0, time.UTC)
+
+func TestPodChaos(t *testing.T) {
+	for _, testCase := range []struct {
+		name                  string
+		givenLabelFilter      string
+		givenAnnotationFilter string
+		givenNamespaceFilter  string
+		givenAgeFilter        time.Duration
+
+		given []runtime.Object
+
+		expectEventuallyChosen []string
+	}{
+		{
+			name:                   "Any pod filter eventually chooses all pods",
+			given:                  []runtime.Object{pod("A"), pod("B")},
+			expectEventuallyChosen: []string{"A", "B"},
+		},
+		{
+			name:                   "Label filter leaves pods alone",
+			givenLabelFilter:       "include=true",
+			given:                  []runtime.Object{pod("A"), pod("B", label("include", "true"))},
+			expectEventuallyChosen: []string{"B"},
+		},
+		{
+			name:                   "Label filter leaves pods alone",
+			givenLabelFilter:       "include!=true",
+			given:                  []runtime.Object{pod("A"), pod("B", label("include", "true"))},
+			expectEventuallyChosen: []string{"A"},
+		},
+		{
+			name:                   "Annocation filter leaves pods alone",
+			givenAnnotationFilter:  "include=true",
+			given:                  []runtime.Object{pod("A"), pod("B", annotation("include", "true"))},
+			expectEventuallyChosen: []string{"B"},
+		},
+		{
+			name:                   "Namespace filter leaves pods alone",
+			givenNamespaceFilter:   "somenamespace",
+			given:                  []runtime.Object{pod("A"), pod("B", namespace("somenamespace"))},
+			expectEventuallyChosen: []string{"B"},
+		},
+		{
+			name:                   "Age filter leaves pods alone",
+			givenAgeFilter:         100 * time.Hour,
+			given:                  []runtime.Object{pod("A"), pod("B", age(1000*time.Hour))},
+			expectEventuallyChosen: []string{"B"},
+		},
+		{
+			name:                   "Only running pods are targeted",
+			given:                  []runtime.Object{pod("A"), pod("B", phase(v1.PodPending))},
+			expectEventuallyChosen: []string{"A"},
+		},
+		{
+			name:                   "No matching pods is ok",
+			givenNamespaceFilter:   "someunusednamespace",
+			given:                  []runtime.Object{pod("A"), pod("B")},
+			expectEventuallyChosen: []string{},
+		},
+	} {
+		tc := testCase // get a local var so testCase doesn't change under our feet
+		t.Run(tc.name, func(t *testing.T) {
+			expectedNames := asMap(tc.expectEventuallyChosen)
+			seenNames := make(map[string]bool)
+			client := fake.NewSimpleClientset(tc.given...)
+			recorder := &recordPodAction{}
+
+			spec := chaoskube.NewPodChaosSpec(recorder, selector(tc.givenLabelFilter),
+				selector(tc.givenAnnotationFilter), selector(tc.givenNamespaceFilter),
+				tc.givenAgeFilter, logger)
+
+			for i := 0; i < 1000; i++ {
+				// When
+				err := spec.Apply(client, now)
+
+				if err != nil {
+					t.Fatalf("Spec application failed: %s", err)
+					return
+				}
+
+				if recorder.lastGivenPod != nil {
+					seenNames[recorder.lastGivenPod.Name] = true
+					if _, ok := expectedNames[recorder.lastGivenPod.Name]; !ok {
+						t.Fatalf("Unexpected pod chosen: %s", recorder.lastGivenPod.Name)
+						return
+					}
+				}
+			}
+
+			for _, expected := range tc.expectEventuallyChosen {
+				if _, ok := seenNames[expected]; !ok {
+					t.Fatalf("Expected pod to be selected: %s", expected)
+				}
+			}
+		})
+	}
+}
+
+type recordPodAction struct {
+	lastGivenPod *v1.Pod
+}
+
+func (a *recordPodAction) ApplyChaos(victim v1.Pod) error {
+	a.lastGivenPod = &victim
+	return nil
+}
+
+func (a *recordPodAction) Name() string {
+	return "record-pod"
+}
+
+func pod(name string, modifiers ...func(*v1.Pod)) runtime.Object {
+	p := util.NewPod("default", name, v1.PodRunning)
+	p.CreationTimestamp = k8smeta.Time{now}
+	for _, mod := range modifiers {
+		mod(&p)
+	}
+	return &p
+}
+
+func label(key, val string) func(pod *v1.Pod) {
+	return func(pod *v1.Pod) {
+		pod.Labels[key] = val
+	}
+}
+
+func annotation(key, val string) func(pod *v1.Pod) {
+	return func(pod *v1.Pod) {
+		pod.Annotations[key] = val
+	}
+}
+
+func namespace(namespace string) func(pod *v1.Pod) {
+	return func(pod *v1.Pod) {
+		pod.Namespace = namespace
+	}
+}
+
+func age(duration time.Duration) func(pod *v1.Pod) {
+	return func(pod *v1.Pod) {
+		pod.CreationTimestamp.Time = now.Add(-duration)
+	}
+}
+
+func phase(phase v1.PodPhase) func(pod *v1.Pod) {
+	return func(pod *v1.Pod) {
+		pod.Status.Phase = phase
+	}
+}
+
+// Utilities
+
+func selector(spec string) labels.Selector {
+	if spec == "" {
+		return labels.Everything()
+	}
+
+	selector, err := labels.Parse(spec)
+	if err != nil {
+		panic(fmt.Sprintf("Test specifies an invalid selector: '%s'. Error: %s", selector, err))
+	}
+
+	return selector
+}
+
+func asMap(list []string) (out map[string]bool) {
+	out = make(map[string]bool, len(list))
+	for _, name := range list {
+		out[name] = true
+	}
+	return
+}

--- a/chaoskube/spec_test.go
+++ b/chaoskube/spec_test.go
@@ -65,6 +65,12 @@ func TestPodChaos(t *testing.T) {
 		{
 			name:                   "Age filter leaves pods alone",
 			givenAgeFilter:         100 * time.Hour,
+			given:                  []runtime.Object{pod("A", age(100*time.Hour)), pod("B")},
+			expectEventuallyChosen: []string{},
+		},
+		{
+			name:                   "Age filter only lets through old-enough pods",
+			givenAgeFilter:         100 * time.Hour,
 			given:                  []runtime.Object{pod("A"), pod("B", age(1000*time.Hour))},
 			expectEventuallyChosen: []string{"B"},
 		},

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
 	"encoding/json"
+	"github.com/stretchr/testify/suite"
 )
 
 type Suite struct {


### PR DESCRIPTION
Best reviewed as separate commits. First one is tiny. Second refactors to move all the pod-specific chaos stuff (ie. selection and action) into a little abstraction ("ChaosSpec"). The third commit uses that abstraction to introduce the ability to stop nodes.

See individual commit messages for details.