### PR TITLE
Drain node action

### DIFF
--- a/chaoskube/action/node_delete.go
+++ b/chaoskube/action/node_delete.go
@@ -11,6 +11,9 @@ func NewDeleteNodeAction() NodeAction {
 
 type deleteNode struct{}
 
+func (s *deleteNode) Init(k8sclient kubernetes.Interface) error {
+	return nil
+}
 func (a *deleteNode) ApplyToNode(client kubernetes.Interface, victim *v1.Node) error {
 	return client.CoreV1().Nodes().Delete(victim.Name, nil)
 }

--- a/chaoskube/action/node_delete.go
+++ b/chaoskube/action/node_delete.go
@@ -1,0 +1,19 @@
+package action
+
+import (
+"k8s.io/api/core/v1"
+"k8s.io/client-go/kubernetes"
+)
+
+func NewDeleteNodeAction() NodeAction {
+	return &deleteNode{}
+}
+
+type deleteNode struct{}
+
+func (a *deleteNode) ApplyToNode(client kubernetes.Interface, victim *v1.Node) error {
+	return client.CoreV1().Nodes().Delete(victim.Name, nil)
+}
+func (a *deleteNode) Name() string {
+	return "delete node"
+}

--- a/chaoskube/action/node_delete.go
+++ b/chaoskube/action/node_delete.go
@@ -1,8 +1,8 @@
 package action
 
 import (
-"k8s.io/api/core/v1"
-"k8s.io/client-go/kubernetes"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func NewDeleteNodeAction() NodeAction {

--- a/chaoskube/action/node_delete_test.go
+++ b/chaoskube/action/node_delete_test.go
@@ -1,7 +1,7 @@
-package chaoskube_test
+package action_test
 
 import (
-	"github.com/neo-technology/marmoset/chaoskube"
+	"github.com/neo-technology/marmoset/chaoskube/action"
 	"k8s.io/api/core/v1"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -20,9 +20,9 @@ func TestDeleteNodeAction(t *testing.T) {
 		},
 	}
 	client := fake.NewSimpleClientset(node, noTouching)
-	action := chaoskube.NewDeleteNodeAction()
+	act := action.NewDeleteNodeAction()
 
-	err := action.ApplyToNode(client, node)
+	err := act.ApplyToNode(client, node)
 
 	if err != nil {
 		t.Fatalf("Expected smooth sailing, got: %s", err)
@@ -39,3 +39,4 @@ func TestDeleteNodeAction(t *testing.T) {
 		t.Fatalf("Expected the extra node to not have been touched, but the surviving node is: %v", nodes.Items[0])
 	}
 }
+

--- a/chaoskube/action/node_delete_test.go
+++ b/chaoskube/action/node_delete_test.go
@@ -39,4 +39,3 @@ func TestDeleteNodeAction(t *testing.T) {
 		t.Fatalf("Expected the extra node to not have been touched, but the surviving node is: %v", nodes.Items[0])
 	}
 }
-

--- a/chaoskube/action/node_drain.go
+++ b/chaoskube/action/node_drain.go
@@ -1,0 +1,147 @@
+package action
+
+import (
+	"fmt"
+	"k8s.io/api/core/v1"
+	k8spolicy "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"time"
+)
+
+const (
+	EvictionKind          = "Eviction"
+	LabelMarmosetCordoned = "marmoset/cordoned"
+)
+
+func NewDrainNodeAction() NodeAction {
+	return &drainNode{}
+}
+
+type drainNode struct{}
+
+func (a *drainNode) ApplyToNode(client kubernetes.Interface, victim *v1.Node) (err error) {
+	victim = victim.DeepCopy()
+	if err = crashRecovery(client); err != nil {
+		return err
+	}
+
+	// No matter what, try to uncordon the node before we're done here
+	defer func() {
+		deferErr := uncordonNode(client, victim)
+		// If there's no other error, set the return error to be whatever the outcome
+		// of the uncordon was; otherwise don't overwrite any prior error.
+		if err == nil {
+			err = deferErr
+		}
+	}()
+
+	// Label and Cordon node
+	victim, err = cordonNode(client, victim)
+	if err != nil {
+		return err
+	}
+
+	// Create evictions for all non-daemon nodes
+	if err = evictAllPodsOnNode(client, victim); err != nil {
+		return err
+	}
+
+	return err
+}
+func (a *drainNode) Name() string {
+	return "cordon node"
+}
+
+func cordonNode(client kubernetes.Interface, victim *v1.Node) (*v1.Node, error) {
+	if victim.Labels == nil {
+		victim.Labels = make(map[string]string, 0)
+	}
+	victim.Labels[LabelMarmosetCordoned] = "true"
+	victim.Spec.Unschedulable = true
+	return client.CoreV1().Nodes().Update(victim)
+}
+
+func uncordonNode(client kubernetes.Interface, victim *v1.Node) error {
+	delete(victim.Labels, LabelMarmosetCordoned)
+	victim.Spec.Unschedulable = false
+	_, err := client.CoreV1().Nodes().Update(victim)
+	return err
+}
+
+// Evict all pods on the given node, respecting PDBs etc.
+// block until all pods evicted, error or 10-minute timeout
+func evictAllPodsOnNode(client kubernetes.Interface, victim *v1.Node) error {
+	pods, err := client.CoreV1().Pods(k8smeta.NamespaceAll).List(k8smeta.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": victim.Name}).String()})
+	if err != nil {
+		return fmt.Errorf("unable to list pods: %s", err)
+	}
+
+	for _, pod := range pods.Items {
+		if err = evictPod(client, &pod); err != nil {
+			return fmt.Errorf("unable to evict pod %s: %s", pod.Name, err)
+		}
+	}
+
+	// Wait for evictions to take effect
+	if err = waitForDelete(client, pods.Items, 1*time.Minute, 10*time.Minute); err != nil {
+		return err
+	}
+	return nil
+}
+
+func evictPod(client kubernetes.Interface, pod *v1.Pod) error {
+	eviction := &k8spolicy.Eviction{
+		TypeMeta: k8smeta.TypeMeta{
+			APIVersion: "v1beta1",
+			Kind:       EvictionKind,
+		},
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		DeleteOptions: nil,
+	}
+	// Remember to change change the URL manipulation func when Evction's version change
+	return client.PolicyV1beta1().Evictions(eviction.Namespace).Evict(eviction)
+}
+
+func waitForDelete(client kubernetes.Interface, pods []v1.Pod, interval, timeout time.Duration) error {
+	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+		pendingPods := []v1.Pod{}
+		for i, pod := range pods {
+			p, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, k8smeta.GetOptions{})
+			if errors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
+				continue
+			} else if err != nil {
+				return false, err
+			} else {
+				pendingPods = append(pendingPods, pods[i])
+			}
+		}
+		pods = pendingPods
+		if len(pendingPods) > 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// To guard against us crashing in the middle of draining a node and not uncordoning it,
+// this finds any node with our marker label and uncordons them.
+func crashRecovery(client kubernetes.Interface) error {
+	nodeList, err := client.CoreV1().Nodes().List(k8smeta.ListOptions{LabelSelector: fmt.Sprintf("%s=true", LabelMarmosetCordoned)})
+	if err != nil {
+		return err
+	}
+	for _, node := range nodeList.Items {
+		if err = uncordonNode(client, &node); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/chaoskube/action/node_drain.go
+++ b/chaoskube/action/node_drain.go
@@ -23,9 +23,12 @@ func NewDrainNodeAction() NodeAction {
 
 type drainNode struct{}
 
+func (s *drainNode) Init(client kubernetes.Interface) error {
+	return crashRecoverNodeDrain(client)
+}
 func (a *drainNode) ApplyToNode(client kubernetes.Interface, victim *v1.Node) (err error) {
 	victim = victim.DeepCopy()
-	if err = crashRecovery(client); err != nil {
+	if err = crashRecoverNodeDrain(client); err != nil {
 		return err
 	}
 
@@ -133,7 +136,7 @@ func waitForDelete(client kubernetes.Interface, pods []v1.Pod, interval, timeout
 
 // To guard against us crashing in the middle of draining a node and not uncordoning it,
 // this finds any node with our marker label and uncordons them.
-func crashRecovery(client kubernetes.Interface) error {
+func crashRecoverNodeDrain(client kubernetes.Interface) error {
 	nodeList, err := client.CoreV1().Nodes().List(k8smeta.ListOptions{LabelSelector: fmt.Sprintf("%s=true", LabelMarmosetCordoned)})
 	if err != nil {
 		return err

--- a/chaoskube/action/node_drain_test.go
+++ b/chaoskube/action/node_drain_test.go
@@ -1,0 +1,180 @@
+package action_test
+
+import (
+	"github.com/neo-technology/marmoset/chaoskube/action"
+	"github.com/neo-technology/marmoset/util"
+	"k8s.io/api/core/v1"
+	k8spolicy "k8s.io/api/policy/v1beta1"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	k8stypedpolicy "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	k8sfakepolicy "k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+func TestDrainNode(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	targetPod := newPodOnNode("p1", node.Name)
+	client := fixPolicyFake(fake.NewSimpleClientset(node, targetPod))
+	client.Fake.PrependReactor("create", "pods", evictionReaction(client.Fake.ReactionChain[0].React))
+	act := action.NewDrainNodeAction()
+
+	// When I apply the drain action..
+	err := act.ApplyToNode(client, node)
+	if err != nil {
+		t.Fatalf("ApplyToNode failed with: %s", err)
+	}
+
+	// Then the first action taken is that node is labeled and unschedulable
+	actions := client.Fake.Actions()
+	actionNo := 1
+	patchNode := actions[actionNo].(k8stesting.UpdateAction).GetObject().(*v1.Node)
+	if patchNode.Labels[action.LabelMarmosetCordoned] != "true" {
+		t.Errorf("Expected node to be labeled %s=true, actual: %v", action.LabelMarmosetCordoned, patchNode.Labels)
+	}
+	if !patchNode.Spec.Unschedulable {
+		t.Errorf("Expected node to be unscheduleable.")
+	}
+	actionNo++
+
+	// After that, the action lists available pods
+	listAction, ok := actions[actionNo].(k8stesting.ListAction)
+	if !ok {
+		t.Errorf("Expected the action to list available pods, found %v", actions[actionNo])
+	}
+	podFilter := listAction.GetListRestrictions().Fields.String()
+	if podFilter != "spec.nodeName=test-node" {
+		t.Errorf("Wrong field filter for listing pods: %s", podFilter)
+	}
+	actionNo++
+
+	// After that, an eviction request is created
+	createEviction := actions[actionNo].(k8stesting.CreateAction)
+	eviction := createEviction.GetObject().(*k8spolicy.Eviction)
+	if eviction.Name != targetPod.Name {
+		t.Errorf("Expected target of eviction to be %s, found %v", targetPod.Name, eviction.Name)
+	}
+	actionNo++
+
+	// After that, it polls to check that the pod is gone
+	pollAction := actions[actionNo].(k8stesting.GetAction)
+	if pollAction.GetName() != targetPod.Name {
+		t.Errorf("Expected target of poll to be %s, found %v", targetPod.Name, pollAction)
+	}
+	actionNo++
+
+	// And finally it uncordons the node
+	uncordonNode := actions[actionNo].(k8stesting.UpdateAction).GetObject().(*v1.Node)
+	if uncordonNode.Labels[action.LabelMarmosetCordoned] != "" {
+		t.Errorf("Expected marmoset label to be cleared, found %v", patchNode.Labels)
+	}
+	if uncordonNode.Spec.Unschedulable {
+		t.Errorf("Expected node to be scheduleable.")
+	}
+	actionNo++
+}
+
+func TestDrainNodeUncordonsAnyPartiallyDrainedNode(t *testing.T) {
+	victim := &v1.Node{
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+	leftCordoned := &v1.Node{
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name:   "cordoned",
+			Labels: map[string]string{action.LabelMarmosetCordoned: "true"},
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+	client := fixPolicyFake(fake.NewSimpleClientset(victim, leftCordoned))
+	act := action.NewDrainNodeAction()
+
+	// When I apply the drain action..
+	err := act.ApplyToNode(client, victim)
+	if err != nil {
+		t.Fatalf("ApplyToNode failed with: %s", err)
+	}
+
+	// Then the already cordoned node is found and uncordoned
+	actions := client.Fake.Actions()
+	patchNode := actions[1].(k8stesting.UpdateAction).GetObject().(*v1.Node)
+	if patchNode.Name != leftCordoned.Name {
+		t.Errorf("Expected %s to be uncordoned, got %v", leftCordoned.Name, patchNode)
+	}
+	if patchNode.Labels[action.LabelMarmosetCordoned] != "" {
+		t.Errorf("Expected node have label cleared, got %v", patchNode.Labels)
+	}
+	if patchNode.Spec.Unschedulable {
+		t.Errorf("Expected node to be made schedulable.")
+	}
+}
+
+func evictionReaction(defaultReaction k8stesting.ReactionFunc) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		if !action.Matches("create", "pods") || action.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+
+		// Act by handling like a delete action
+		eviction := action.(k8stesting.CreateAction).GetObject().(*k8spolicy.Eviction)
+		return defaultReaction(k8stesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, eviction.Namespace, eviction.Name))
+	}
+}
+
+func newPodOnNode(podName, nodeName string) *v1.Pod {
+	pod := util.NewPod("default", podName, v1.PodRunning)
+	pod.Spec.NodeName = nodeName
+	return &pod
+}
+
+// Decorate fake.Clientset to workaround issues in the policy fakes fixed by
+// https://github.com/kubernetes/client-go/commit/e2d85a507946471958cfba11f58b217cb9a1b1f1
+// This can be dropped once we upgrade to a client version that has that patch; currently there is no
+// client release with this patch.
+func fixPolicyFake(client *fake.Clientset) *clientset {
+	return &clientset{client}
+}
+
+type clientset struct {
+	*fake.Clientset
+}
+
+func (c *clientset) PolicyV1beta1() k8stypedpolicy.PolicyV1beta1Interface {
+	return &fakePolicyV1beta1{k8sfakepolicy.FakePolicyV1beta1{Fake: &c.Fake}}
+}
+
+type fakePolicyV1beta1 struct {
+	k8sfakepolicy.FakePolicyV1beta1
+}
+
+func (c *fakePolicyV1beta1) Evictions(namespace string) v1beta1.EvictionInterface {
+	return &FakeEvictions{&c.FakePolicyV1beta1, namespace}
+}
+
+// FakeEvictions implements EvictionInterface
+type FakeEvictions struct {
+	Fake *k8sfakepolicy.FakePolicyV1beta1
+	ns   string
+}
+
+func (c *FakeEvictions) Evict(eviction *k8spolicy.Eviction) error {
+	action := k8stesting.CreateActionImpl{}
+	action.Verb = "create"
+	action.Namespace = c.ns
+	action.Resource = schema.GroupVersionResource{Group: "", Version: "", Resource: "pods"}
+	action.Subresource = "eviction"
+	action.Object = eviction
+	_, err := c.Fake.Invokes(action, eviction)
+	return err
+}

--- a/chaoskube/action/pod_delete.go
+++ b/chaoskube/action/pod_delete.go
@@ -1,0 +1,22 @@
+package action
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func NewDeletePodAction(client kubernetes.Interface) PodAction {
+	return &deletePod{client}
+}
+
+// Simply ask k8s to delete the victim pod
+type deletePod struct {
+	client kubernetes.Interface
+}
+
+func (s *deletePod) ApplyToPod(victim v1.Pod) error {
+	return s.client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
+}
+func (s *deletePod) Name() string { return "delete pod" }
+
+var _ PodAction = &deletePod{}

--- a/chaoskube/action/pod_delete.go
+++ b/chaoskube/action/pod_delete.go
@@ -14,6 +14,9 @@ type deletePod struct {
 	client kubernetes.Interface
 }
 
+func (s *deletePod) Init(k8sclient kubernetes.Interface) error {
+	return nil
+}
 func (s *deletePod) ApplyToPod(victim v1.Pod) error {
 	return s.client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
 }

--- a/chaoskube/action/pod_dry_run.go
+++ b/chaoskube/action/pod_dry_run.go
@@ -1,0 +1,20 @@
+package action
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+func NewDryRunPodAction() PodAction {
+	return &podDryRun{}
+}
+
+// no-op
+type podDryRun struct {
+}
+
+func (s *podDryRun) ApplyToPod(victim v1.Pod) error {
+	return nil
+}
+func (s *podDryRun) Name() string { return "dry run" }
+
+var _ PodAction = &podDryRun{}

--- a/chaoskube/action/pod_dry_run.go
+++ b/chaoskube/action/pod_dry_run.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func NewDryRunPodAction() PodAction {
@@ -12,6 +13,9 @@ func NewDryRunPodAction() PodAction {
 type podDryRun struct {
 }
 
+func (s *podDryRun) Init(k8sclient kubernetes.Interface) error {
+	return nil
+}
 func (s *podDryRun) ApplyToPod(victim v1.Pod) error {
 	return nil
 }

--- a/chaoskube/action/pod_exec.go
+++ b/chaoskube/action/pod_exec.go
@@ -3,6 +3,7 @@ package action
 import (
 	"fmt"
 	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -20,6 +21,10 @@ type execOnPod struct {
 
 	containerName string
 	command       []string
+}
+
+func (s *execOnPod) Init(k8sclient kubernetes.Interface) error {
+	return nil
 }
 
 // Based on https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/exec.go

--- a/chaoskube/action/types.go
+++ b/chaoskube/action/types.go
@@ -6,6 +6,8 @@ import (
 )
 
 type NodeAction interface {
+	// Called once at startup, do any initial setup here
+	Init(k8sclient kubernetes.Interface) error
 	// Imbue chaos in the given victim
 	ApplyToNode(client kubernetes.Interface, victim *v1.Node) error
 	// Name of this action, ideally a verb - like "terminate pod"
@@ -13,6 +15,8 @@ type NodeAction interface {
 }
 
 type PodAction interface {
+	// Called once at startup, do any initial setup here
+	Init(k8sclient kubernetes.Interface) error
 	// Imbue chaos in the given victim
 	ApplyToPod(victim v1.Pod) error
 	// Name of this action, ideally a verb - like "terminate pod"

--- a/chaoskube/action/types.go
+++ b/chaoskube/action/types.go
@@ -1,0 +1,20 @@
+package action
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type NodeAction interface {
+	// Imbue chaos in the given victim
+	ApplyToNode(client kubernetes.Interface, victim *v1.Node) error
+	// Name of this action, ideally a verb - like "terminate pod"
+	Name() string
+}
+
+type PodAction interface {
+	// Imbue chaos in the given victim
+	ApplyToPod(victim v1.Pod) error
+	// Name of this action, ideally a verb - like "terminate pod"
+	Name() string
+}

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -67,6 +67,12 @@ func New(client kubernetes.Interface, spec ChaosSpec, excludedWeekdays []time.We
 // Run continuously picks and terminates a victim pod at a given interval
 // described by channel next. It returns when the given context is canceled.
 func (c *Chaoskube) Run(ctx context.Context, next <-chan time.Time) {
+	initErr := c.Spec.Init(c.Client)
+	if initErr != nil {
+		c.Logger.WithField("err", initErr).Error("init failed")
+		return
+	}
+
 	for {
 		c.Logger.Debug("sleeping...")
 		select {

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -127,7 +127,7 @@ func (suite *Suite) TestDelay() {
 }
 
 type countingSpec struct {
-	counter uint64
+	counter       uint64
 	initCallCount uint64
 }
 
@@ -145,7 +145,6 @@ func (c *countingSpec) currentCount() uint64 {
 func (c *countingSpec) currentInitCount() uint64 {
 	return atomic.LoadUint64(&c.initCallCount)
 }
-
 
 func (suite *Suite) TestTerminateVictim() {
 	midnight := util.NewTimePeriod(

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -2,6 +2,7 @@ package chaoskube
 
 import (
 	"context"
+	"github.com/neo-technology/marmoset/chaoskube/action"
 	"github.com/neo-technology/marmoset/util"
 	"sync/atomic"
 	"testing"
@@ -479,13 +480,13 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 	logOutput.Reset()
 
 	client := fake.NewSimpleClientset()
-	action := NewDeletePodAction(client)
+	act := action.NewDeletePodAction(client)
 	if dryRun {
-		action = NewDryRunPodAction()
+		act = action.NewDryRunPodAction()
 	}
 
 	chaosSpec := &PodChaosSpec{
-		Action:      action,
+		Action:      act,
 		Labels:      labelSelector,
 		Annotations: annotations,
 		Namespaces:  namespaces,

--- a/chaoskube/spec.go
+++ b/chaoskube/spec.go
@@ -14,6 +14,8 @@ import (
 )
 
 type ChaosSpec interface {
+	// Ran once when the chaos monkey starts; for any one-time initialization
+	Init(k8sclient clientset.Interface) error
 	Apply(k8sclient clientset.Interface, now time.Time) error
 }
 
@@ -23,6 +25,10 @@ type NodeChaosSpec struct {
 	Action action.NodeAction
 	// an instance of logrus.StdLogger to write log messages to
 	Logger log.FieldLogger
+}
+
+func (s *NodeChaosSpec) Init(k8sclient clientset.Interface) error {
+	return s.Action.Init(k8sclient)
 }
 
 func (s *NodeChaosSpec) Apply(client clientset.Interface, now time.Time) error {
@@ -78,6 +84,10 @@ type PodChaosSpec struct {
 	MinimumAge time.Duration
 	// an instance of logrus.StdLogger to write log messages to
 	Logger log.FieldLogger
+}
+
+func (s *PodChaosSpec) Init(k8sclient clientset.Interface) error {
+	return s.Action.Init(k8sclient)
 }
 
 func (s *PodChaosSpec) Apply(client clientset.Interface, now time.Time) error {

--- a/chaoskube/spec.go
+++ b/chaoskube/spec.go
@@ -2,6 +2,7 @@ package chaoskube
 
 import (
 	"fmt"
+	"github.com/neo-technology/marmoset/chaoskube/action"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ type ChaosSpec interface {
 // == Node chaos ==
 
 type NodeChaosSpec struct {
-	Action NodeAction
+	Action action.NodeAction
 	// an instance of logrus.StdLogger to write log messages to
 	Logger log.FieldLogger
 }
@@ -56,7 +57,7 @@ func (s *NodeChaosSpec) candidates(client clientset.Interface, now time.Time) ([
 	return nodes, nil
 }
 
-func NewNodeChaosSpec(action NodeAction, logger log.FieldLogger) ChaosSpec {
+func NewNodeChaosSpec(action action.NodeAction, logger log.FieldLogger) ChaosSpec {
 	return &NodeChaosSpec{
 		Action: action,
 		Logger: logger,
@@ -66,7 +67,7 @@ func NewNodeChaosSpec(action NodeAction, logger log.FieldLogger) ChaosSpec {
 // == Pod chaos ==
 
 type PodChaosSpec struct {
-	Action PodAction
+	Action action.PodAction
 	// a label selector which restricts the pods to choose from
 	Labels labels.Selector
 	// an annotation selector which restricts the pods to choose from
@@ -121,7 +122,7 @@ func (s *PodChaosSpec) candidates(client clientset.Interface, now time.Time) ([]
 	return pods, nil
 }
 
-func NewPodChaosSpec(action PodAction, labels, annotations, namespaces labels.Selector, minimumAge time.Duration,
+func NewPodChaosSpec(action action.PodAction, labels, annotations, namespaces labels.Selector, minimumAge time.Duration,
 	logger log.FieldLogger) ChaosSpec {
 	return &PodChaosSpec{
 		Action:      action,

--- a/chaoskube/spec_test.go
+++ b/chaoskube/spec_test.go
@@ -182,7 +182,7 @@ func TestNodeChaos(t *testing.T) {
 func TestNodeSpecInitDelegatesToActionInit(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	action := &recordNodeAction{}
-	spec := chaoskube.NodeChaosSpec{Action:action}
+	spec := chaoskube.NodeChaosSpec{Action: action}
 
 	err := spec.Init(client)
 
@@ -197,7 +197,7 @@ func TestNodeSpecInitDelegatesToActionInit(t *testing.T) {
 func TestPodSpecInitDelegatesToActionInit(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	action := &recordPodAction{}
-	spec := chaoskube.PodChaosSpec{Action:action}
+	spec := chaoskube.PodChaosSpec{Action: action}
 
 	err := spec.Init(client)
 
@@ -210,7 +210,7 @@ func TestPodSpecInitDelegatesToActionInit(t *testing.T) {
 }
 
 type recordPodAction struct {
-	lastGivenPod *v1.Pod
+	lastGivenPod         *v1.Pod
 	initCalledWithClient kubernetes.Interface
 }
 
@@ -227,7 +227,7 @@ func (a *recordPodAction) Name() string {
 }
 
 type recordNodeAction struct {
-	lastGivenNode *v1.Node
+	lastGivenNode        *v1.Node
 	initCalledWithClient kubernetes.Interface
 }
 

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ const (
 	ACTION_DELETE_POD  = "delete-pod"
 	ACTION_EXEC_POD    = "exec-pod"
 	ACTION_DELETE_NODE = "delete-node"
+	ACTION_DRAIN_NODE  = "drain-node"
 )
 
 func init() {
@@ -77,7 +78,7 @@ func init() {
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)
 	kingpin.Flag("exec", "Command to use in 'exec' action").StringVar(&exec)
 	kingpin.Flag("exec-container", "Name of container to run --exec command in, defaults to first container in spec").Default("").StringVar(&execContainer)
-	kingpin.Flag("action", "Type of action: dry-run, delete-pod, exec-pod, delete-node").Default(ACTION_DRY_RUN).StringVar(&actionName)
+	kingpin.Flag("action", "Type of action: dry-run, delete-pod, exec-pod, delete-node, drain-node").Default(ACTION_DRY_RUN).StringVar(&actionName)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&debug)
 	kingpin.Flag("log-format", "'plain' or 'json'").Default("plain").StringVar(&logFormat)
 	kingpin.Flag("log-fields", "key=value, comma separated list of fields to include in every log message").Default("").StringVar(&logFields)
@@ -206,6 +207,8 @@ func main() {
 		}
 	case ACTION_DELETE_NODE:
 		spec = chaoskube.NewNodeChaosSpec(action.NewDeleteNodeAction(), logger)
+	case ACTION_DRAIN_NODE:
+		spec = chaoskube.NewNodeChaosSpec(action.NewDrainNodeAction(), logger)
 	default:
 		panic(fmt.Sprintf("Unknown action: '%s'", actionName))
 	}


### PR DESCRIPTION
Three commits:

- Refactor actions into smaller files (because Drain is big)
- Drain action
- Init feature to allow actions a one-time init; drain uses this to clean up crashes